### PR TITLE
`baseurl` support

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,7 +3,6 @@ email: me@yegor256.com
 description: >
   This site is a static blog for Jekyll and GitHub Pages,
   a demo for "256 Bloghacks" book by Yegor Bugayenko
-baseurl: ""
 url: "http://bloghacks.yegor256.com"
 twitter_username: yegor256
 github_username: yegor256

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -9,20 +9,20 @@ layout: compress
     <meta name="description" content="{{ page.description }}" />
     <meta name="keywords" content="{{ page.keywords | join:', ' | xml_escape }}" />
     <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1"/>
-    <link rel="shortcut icon" href="/favicon.ico"/>
+    <link rel="shortcut icon" href="{{ site.baseurl }}/favicon.ico"/>
     <title>{{ page.title }}</title>
-    <link rel="stylesheet" href="/css/main.css"/>
+    <link rel="stylesheet" href="{{ site.baseurl }}/css/main.css"/>
   </head>
   <body>
     <section>
       <header>
-        <a href="/about.html">
-          <img src="/images/tomato.svg" class="photo" alt="tomato" itemprop="image"/>
+        <a href="{{ site.baseurl }}/about.html">
+          <img src="{{ site.baseurl }}/images/tomato.svg" class="photo" alt="tomato" itemprop="image"/>
         </a>
         <nav>
           <ul>
-            <li><a href="/">Home</a></li>
-            <li><a href="/about.html">About</a></li>
+            <li><a href="{{ site.baseurl }}/">Home</a></li>
+            <li><a href="{{ site.baseurl }}/about.html">About</a></li>
           </ul>
         </nav>
         <nav>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -4,7 +4,7 @@ layout: default
 
 <article itemscope="" itemtype="http://schema.org/BlogPosting">
   <div itemprop="image" itemscope="" itemtype="http://schema.org/ImageObject">
-    <meta itemprop="url" content="{{ site.url }}/images/tomato.png"/>
+    <meta itemprop="url" content="{{ site.url }}{{ site.baseurl }}/images/tomato.png"/>
     <meta itemprop="height" content="250"/>
     <meta itemprop="width" content="250"/>
   </div>
@@ -15,7 +15,7 @@ layout: default
   <div itemscope="" itemprop="publisher" itemtype="http://schema.org/Organization">
     <meta itemprop="name" content="256 Bloghacks"/>
     <div itemprop="logo" itemscope="" itemtype="http://schema.org/ImageObject">
-      <meta itemprop="url" content="{{ site.url }}/images/tomato.png"/>
+      <meta itemprop="url" content="{{ site.url }}{{ site.baseurl }}/images/tomato.png"/>
       <meta itemprop="height" content="250"/>
       <meta itemprop="width" content="250"/>
     </div>


### PR DESCRIPTION
This repository looks like a template and `Feel free to clone it and copy.`. I expect that new users will try to use default Github Pages for hosting this.

But now this template is not working with `baseurl`. `baseurl` is using by Github Actions. For example, I create repository in organization, upload template and try to run. Github Action provide me url `https://OrgName.github.io/RepoName`. Part `/RepoName` is `baseurl` that specified in default Jekyll workflow: `run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"`. As result, generate side cannot find files with url `/css`, `/images/tomato.svg` etc.

Adding `{{ site.baseurl }}` resolve my issues with missed css.